### PR TITLE
Install errands on subway instead of new instance groups.

### DIFF
--- a/operators/cf-integration.yml
+++ b/operators/cf-integration.yml
@@ -37,47 +37,33 @@
   value: ((broker-route-uri))
 
 - type: replace
-  path: /instance_groups/-
+  path: /instance_groups/name=subway/jobs/-
   value:
     name: broker-registrar
-    instances: 1
-    azs: [z1]
+    release: broker-registrar
     lifecycle: errand
-    vm_type: default
-    stemcell: default
-    networks: [{name: default}]
-    jobs:
-    - name: broker-registrar
-      release: broker-registrar
-      consumes:
-        servicebroker:
-          from: broker
-      properties:
-        cf:
-          api_url: ((cf-api-url))
-          username: ((cf-admin-username))
-          password: ((cf-admin-password))
-          skip_ssl_validation: ((cf-skip-ssl-validation))
+    consumes:
+      servicebroker:
+        from: broker
+    properties:
+      cf:
+        api_url: ((cf-api-url))
+        username: ((cf-admin-username))
+        password: ((cf-admin-password))
+        skip_ssl_validation: ((cf-skip-ssl-validation))
 
 - type: replace
-  path: /instance_groups/-
+  path: /instance_groups/name=subway/jobs/-
   value:
     name: broker-deregistrar
-    instances: 1
-    azs: [z1]
+    release: broker-registrar
     lifecycle: errand
-    vm_type: default
-    stemcell: default
-    networks: [{name: default}]
-    jobs:
-    - name: broker-deregistrar
-      release: broker-registrar
-      consumes:
-        servicebroker:
-          from: broker
-      properties:
-        cf:
-          api_url: ((cf-api-url))
-          username: ((cf-admin-username))
-          password: ((cf-admin-password))
-          skip_ssl_validation: ((cf-skip-ssl-validation))
+    consumes:
+      servicebroker:
+        from: broker
+    properties:
+      cf:
+        api_url: ((cf-api-url))
+        username: ((cf-admin-username))
+        password: ((cf-admin-password))
+        skip_ssl_validation: ((cf-skip-ssl-validation))


### PR DESCRIPTION
Requires bosh-release v263+

Doing it this way makes running the errand after a deploy *much* faster (esp during CI) as a new instance group need not be created.